### PR TITLE
Fix fakerecipe overwriting cache recipe on start, reduce dependency o…

### DIFF
--- a/my-app/src/components/MDAnswer.jsx
+++ b/my-app/src/components/MDAnswer.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import styled from "styled-components";
 import { Row, Container, Button } from "react-bootstrap";
 import RecommendedCard from "../components/RecommendedCard";

--- a/my-app/src/components/MDQuestion.jsx
+++ b/my-app/src/components/MDQuestion.jsx
@@ -16,9 +16,9 @@ const StyledQnContainer = styled.div`
   margin: 2rem;
 `;
 
-const MDQuestion = ({ setPreference, setShowAns }) => {
+const MDQuestion = ({ setPreference }) => {
   //State for MDQuestion
-  const pref = JSON.parse(localStorage.getItem("preference"));
+  // const pref = JSON.parse(localStorage.getItem("preference"));
   const [mealType, setMealType] = useState(null);
   const [difficulty, setDifficulty] = useState(null);
   const [cuisine, setCuisine] = useState(null);
@@ -32,14 +32,13 @@ const MDQuestion = ({ setPreference, setShowAns }) => {
           difficulty === "Easy" ? "20" : difficulty === "Medium" ? "40" : "60",
       };
 
-      const rawPreference = {
-        mealType,
-        cuisine,
-        difficulty,
-      };
+      // const rawPreference = {
+      //   mealType,
+      //   cuisine,
+      //   difficulty,
+      // };
 
       setPreference(preference);
-      setShowAns(true);
     }
   }, [mealType, difficulty, cuisine, setPreference]);
 
@@ -101,7 +100,7 @@ const MDQuestion = ({ setPreference, setShowAns }) => {
           setOption={setMealType}
           option={mealType}
         />
-        
+
         <MyDropdownButton
           title="Difficulty"
           optionList={diffTypes}

--- a/my-app/src/components/MyDropdownButton.js
+++ b/my-app/src/components/MyDropdownButton.js
@@ -17,8 +17,10 @@ const MyDropdownButton = ({ title, optionList, setOption, option }) => {
         id="dropdown-basic-button"
         title={option ? option : title}
       >
-        {optionList.map((type) => (
-          <Dropdown.Item onClick={() => setOption(type)}>{type}</Dropdown.Item>
+        {optionList.map((type, index) => (
+          <Dropdown.Item key={index} onClick={() => setOption(type)}>
+            {type}
+          </Dropdown.Item>
         ))}
       </DropdownButton>
     </StyledBox>

--- a/my-app/src/components/RecipeIngredients.jsx
+++ b/my-app/src/components/RecipeIngredients.jsx
@@ -19,8 +19,8 @@ class RecipeIngredients extends Component {
         <h4>Ingredients</h4>
         <ul>
           {ingredients &&
-            ingredients.map((ingredient) => {
-              return <li key={ingredient.id}>{ingredient.original}</li>;
+            ingredients.map((ingredient, index) => {
+              return <li key={index}>{ingredient.original}</li>;
             })}
         </ul>
       </Wrapper>


### PR DESCRIPTION
- recipeId useEffect was overwriting recipe state on start, causing the card to show fakerecipe. FIXED by only allowing setting the state of recipe when recipeId !=null

- FIXED Unnecessary fetch on start due to recipeId useEffect as we are already caching recipe.

- Remove duplicate fetch recipe information.

- Move setShowAns from MDQuestion to main


